### PR TITLE
FI-1684: TLS warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ versions. In the example below, only TLS 1.1 and 1.2 are permitted, and TLS 1.2
 is required. All other versions are forbidden. No minimum/maximum allowed
 version is enforced if none are specified.
 
+The `incorrectly_permitted_tls_version_message_type` option allows you to
+determine the behavior of the test when a server allows a TLS connection to be
+established using an unpermitted version. It defaults to `'error'`, which will
+cause the test to fail when a connection is established using an unpermitted
+version. Values of `'info'` or `'warning'` will allow the test to still pass
+with details in an info or warning message.
+
 ```ruby
 require 'tls_test_kit'
 
@@ -54,7 +61,8 @@ test from: :tls_version_test do
     options: {
       minimum_allowed_version: OpenSSL::SSL::TLS1_1_VERSION,
       maximum_allowed_version: OpenSSL::SSL::TLS1_2_VERSION,
-      required_versions: [OpenSSL::SSL::TLS1_2_VERSION]
+      required_versions: [OpenSSL::SSL::TLS1_2_VERSION],
+      incorrectly_permitted_tls_version_message_type: 'warning'
     }
   )
 end

--- a/lib/tls_test_kit/tls_version_test.rb
+++ b/lib/tls_test_kit/tls_version_test.rb
@@ -107,7 +107,7 @@ module TLSTestKit
 
       warning_messages = messages.select { |message| message[:type] == 'warning' }
 
-      output tls_warning_messages: JSON.generate(warning_messages)
+      output tls_warning_messages: warning_messages.map { |message| message[:message] }.join("\n")
 
       errors_found = messages.any? { |message| message[:type] == 'error' }
 

--- a/lib/tls_test_kit/tls_version_test.rb
+++ b/lib/tls_test_kit/tls_version_test.rb
@@ -94,7 +94,7 @@ module TLSTestKit
 
             add_message(self.class.incorrectly_permitted_tls_version_message_type, message)
           elsif self.class.version_required? version
-            add_message('info', "#{url} correctly allowed #{version_string} connection as required.")
+            add_message('info', "#{url} correctly accepted #{version_string} connection as required.")
             tls_support_verified = true
           else
             add_message('info', "#{url} allowed #{version_string} connection.")

--- a/lib/tls_test_kit/tls_version_test.rb
+++ b/lib/tls_test_kit/tls_version_test.rb
@@ -120,7 +120,7 @@ module TLSTestKit
       assert tls_support_verified, 'Server did not support any allowed TLS versions.'
 
       if incorrectly_permitted_tls_versions.present?
-        pass "Server allowed TLS connections using versions which should not be permitted: #{incorrectly_permitted_tls_versions.join(', ')}"
+        pass "Server accepted TLS connections using versions which should be denied: #{incorrectly_permitted_tls_versions.join(', ')}"
       end
     end
   end

--- a/lib/tls_test_kit/tls_version_test.rb
+++ b/lib/tls_test_kit/tls_version_test.rb
@@ -97,7 +97,7 @@ module TLSTestKit
             add_message('info', "#{url} correctly accepted #{version_string} connection as required.")
             tls_support_verified = true
           else
-            add_message('info', "#{url} allowed #{version_string} connection.")
+            add_message('info', "#{url} accepted #{version_string} connection.")
             tls_support_verified = true
           end
         rescue StandardError => e


### PR DESCRIPTION
# Summary
This branch allows authors to control the type of message generated when a server accepts a TLS connection over a version which should not be permitted. It defaults to `error`, which matches the current behavior.

# Testing Guidance
The Single Patient and EHR Launch groups (STU1) in the g10 test kit have been updated to use this functionality in the `fi-1684-update-tls-tests` branch. If you run those groups against the dev or qa servers, you will see that the TLS tests pass even though connections using unpermitted versions are allowed.
