### PR TITLE
FI-2398: TLS Version Test Skip Fix

### DIFF
--- a/lib/tls_test_kit/tls_version_test.rb
+++ b/lib/tls_test_kit/tls_version_test.rb
@@ -70,6 +70,7 @@ module TLSTestKit
     input :url
 
     run do
+      skip_if url.blank?, "Could not verify when no url provided."
       uri = URI(url)
       host = uri.host
       port = uri.port

--- a/lib/tls_test_kit/tls_version_test.rb
+++ b/lib/tls_test_kit/tls_version_test.rb
@@ -71,6 +71,7 @@ module TLSTestKit
 
     run do
       skip_if url.blank?, "Could not verify when no url provided."
+      
       uri = URI(url)
       host = uri.host
       port = uri.port


### PR DESCRIPTION
# Summary

This PR makes the tls_version_test test skip when no url input is passed in. Previously, the tls version test returns an error if no valid url input is passed into the test. However, in the bulk data test kit, the url input for this test can occasionally be empty when the test before fails, since the url input is the output of the previous test. This PR fixes the tls version test so that it skips rather than throwing an error when a url input is not passed in.

# Testing Guidance
Run test kit locally and make sure test skips when url input is a space
