### PR TITLE
Ignore *.gem files in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 /docs/yard
 .yardoc
 node_modules
+*.gem


### PR DESCRIPTION
# Summary

Since we're ignoring *.gem files in inferno template, we should ignore them here too.

# Testing Guidance
1. checkout this branch
2. `touch dummy.gem`
3. `git status` -> verify no .gem files show
4. `rm dummy.gem` to clean up