### PR TITLE
FI-3367 Disable TLS from Env

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ test from: :tls_version_test do
 end
 ```
 
+## Disabling the TLS Test
+
+If the environment variable `INFERNO_DISABLE_TLS_TEST` is present the test always result in `omit`. This is intended
+for continuous integration testing.
+
 ## License
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use

--- a/README.md
+++ b/README.md
@@ -70,8 +70,10 @@ end
 
 ## Disabling the TLS Test
 
-If the environment variable `INFERNO_DISABLE_TLS_TEST` is present the test always result in `omit`. This is intended
-for continuous integration testing.
+If the environment variable `INFERNO_DISABLE_TLS_TEST` equals `"true"`
+(case-insensitive) then test always result in `omit`. To view this behavior you
+can do `INFERNO_DISABLE_TLS_TEST=true inferno start` when starting Inferno.
+This is intended for continuous integration testing.
 
 ## License
 

--- a/lib/tls_test_kit/tls_version_test.rb
+++ b/lib/tls_test_kit/tls_version_test.rb
@@ -70,7 +70,8 @@ module TLSTestKit
     input :url
 
     run do
-      omit_if ENV['INFERNO_DISABLE_TLS_TEST'], "This test is disabled because INFERNO_DISABLE_TLS_TEST is present in env."
+      omit_if ENV.fetch('INFERNO_DISABLE_TLS_TEST', 'false').casecmp?('true'),
+              "This test is disabled because INFERNO_DISABLE_TLS_TEST is present in env."
       skip_if url.blank?, "Could not verify when no url provided."
       
       uri = URI(url)

--- a/lib/tls_test_kit/tls_version_test.rb
+++ b/lib/tls_test_kit/tls_version_test.rb
@@ -70,6 +70,7 @@ module TLSTestKit
     input :url
 
     run do
+      omit_if ENV['INFERNO_DISABLE_TLS_TEST'], "This test is disabled because INFERNO_DISABLE_TLS_TEST is present in env."
       skip_if url.blank?, "Could not verify when no url provided."
       
       uri = URI(url)


### PR DESCRIPTION
# Summary

If `INFERNO_DISABLE_TLS_TEST` is in env the test will mark itself as `omit`.

# Testing Guidance

1. Checkout this branch
2. `bundle exec inferno services start`
3. `INFERNO_DISABLE_TLS_TEST=true bundle exec inferno start`
4. Go to <http://127.0.0.1:4567/> and run test against https://inferno.healthit.gov. Test should be omitted and not passed.