### PR TITLE
ID-5: Fix Docker execution and session creation

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,2 +1,3 @@
 REDIS_URL=redis://redis:6379/0
+INFERNO_HOST=http://localhost
 VALIDATOR_URL=http://validator_service:4567

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ WORKDIR $INSTALL_PATH
 
 ADD *.gemspec $INSTALL_PATH
 ADD Gemfile* $INSTALL_PATH
+ADD lib/tls_test_kit/version.rb $INSTALL_PATH/lib/tls_test_kit/version.rb
 RUN gem install bundler
 # The below RUN line is commented out for development purposes, because any change to the 
 # required gems will break the dockerfile build process.


### PR DESCRIPTION
# Summary

Previously, when this test kit could not be [run locally in docker](https://inferno-framework.github.io/docs/getting-started-users.html#running-an-existing-test-kit). Now it can and users are correctly redirected to the main Inferno UI when a session is created.

# Testing Guidance

1. Start the test kit [using docker](https://inferno-framework.github.io/docs/getting-started-users.html#running-an-existing-test-kit).
2. Open http://localhost in a web browser.
3. Click the "Start Testing" button.
4. Confirm that a web page for the testing session opens correctly.